### PR TITLE
Build and Load fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ builtins
 ## JetBrains
 .idea/
 *.iml
+/.editor_settings

--- a/wortal/include/wortal_session.h
+++ b/wortal/include/wortal_session.h
@@ -26,6 +26,7 @@ public:
     static int OnOrientationChange(lua_State *L);
     static int SwitchGameAsync(lua_State *L);
     static int IsAudioEnabled(lua_State *L);
+    static int OnAudioStatusChange(lua_State *L);
 
 private:
     static void OnGetEntryPoint(const char *entryPoint, const char *error);

--- a/wortal/manifests/web/engine_template.html
+++ b/wortal/manifests/web/engine_template.html
@@ -6,16 +6,34 @@
 <body>
     <script>
         if (Wortal) {
+            // Copied from https://github.com/defold/extension-poki-sdk/blob/main/poki-sdk/manifests/web/engine_template.html
+            var isWasmLoaded = false;
+            var isWortalSDKInited = false;
+            var runFunc = function () {
+                if (isWortalSDKInited && isWasmLoaded) {
+                    Module.runApp("canvas");
+                }
+            }
+            Module['onRuntimeInitialized'] = function () {
+                isWasmLoaded = true;
+                runFunc();
+            };
+
             // This should be called as soon as possible as the SDK cannot be used until it's finished initializing.
             Wortal.initializeAsync().then(() => {
                 // SDK ready to use, you can start the game now. If your game is still loading assets then you can
                 // comment out the startGameAsync call and call it when your game is ready.
+
+                isWortalSDKInited = true;
+                runFunc();
                 Wortal.startGameAsync().then(() => {
                     // Game ready to play, player is shown the game.
                 }).catch(err => {
                     console.error(err);
                 });
             }).catch(err => {
+                isWortalSDKInited = true;
+                runFunc();
                 console.error(err);
             });
         } else {

--- a/wortal/src/wortal.cpp
+++ b/wortal/src/wortal.cpp
@@ -298,6 +298,7 @@ static const luaL_reg Module_methods[] = {
     {"session_get_orientation", WortalSession::GetOrientation},
     {"session_on_orientation_change", WortalSession::OnOrientationChange},
     {"session_switch_game", WortalSession::SwitchGameAsync},
+    {"session_on_audio_status_change", WortalSession::OnAudioStatusChange},
 
     {"stats_get_stats", WortalStats::GetStatsAsync},
     {"stats_post_stats", WortalStats::PostStatsAsync},

--- a/wortal/src/wortal.cpp
+++ b/wortal/src/wortal.cpp
@@ -84,8 +84,8 @@ void Wortal::OnResume(const int success)
     lua_State *L = onResumeListener.m_L;
     int top = lua_gettop(L);
 
-    lua_pushListener(L, onResumeListener);
-    lua_pushBoolean(L, success);
+    lua_pushlistener(L, onResumeListener);
+    lua_pushboolean(L, success);
 
     int ret = lua_pcall(L, 2, 0, 0);
     if (ret != 0)

--- a/wortal/src/wortal_session.cpp
+++ b/wortal/src/wortal_session.cpp
@@ -1,5 +1,6 @@
 #include "wortal_session.h"
 #include "luautils.h"
+#include <dmsdk/dlib/log.h>
 
 #if defined(DM_PLATFORM_HTML5)
 
@@ -107,7 +108,7 @@ void WortalSession::OnAudioStatusChange(const bool *isAudioEnabled)
     {
         // just for debugging purpose.
         const char *error = lua_tostring(L, -1);
-        std::cerr << "Lua error in OnAudioStatusChange : " << error << std::endl;
+        dmLogError("Lua error in OnAudioStatusChange : %s", error)
 
         lua_pop(L, 1);
     }


### PR DESCRIPTION
1. Fix syntax errors.
If you open project and try to Build HTML5, you'll get build errors:
<img width="1049" alt="Screenshot 2025-01-23 at 21 07 17" src="https://github.com/user-attachments/assets/3a7598e4-1f71-43f4-b05e-c68ff8ea7645" />

**Last build wasn't working at all because of this error...**

2. Fix error when game loads faster than SDK.

In HTML5 build, if game is loaded faster than Wortal SDK, you'll get errors in console and game will crash:
<img width="1470" alt="Screenshot 2025-01-23 at 20 16 05" src="https://github.com/user-attachments/assets/9c14f2c7-23d3-461b-8498-d372936c8ebb" />
<img width="1470" alt="Screenshot 2025-01-23 at 20 16 33" src="https://github.com/user-attachments/assets/a6417f30-7247-4167-af83-a85cc0055bb7" />
<img width="1470" alt="Screenshot 2025-01-23 at 20 16 43" src="https://github.com/user-attachments/assets/cf1b1bec-f20f-4751-a4fe-a272aa89812b" />
Now game loaded and waits for Wortal.initializeAsync.

4. Add OnAudioStatusChange Lua binding.

Function `WortalSession::OnAudioStatusChange` was implemented, but Lua binding for it was missing.
